### PR TITLE
Fix carousel-indicators active

### DIFF
--- a/src/carousel/carousel.js
+++ b/src/carousel/carousel.js
@@ -268,7 +268,7 @@ angular.module('ui.bootstrap.carousel', [])
       return attrs.templateUrl || 'uib/template/carousel/carousel.html';
     },
     scope: {
-      active: '=',
+      active: '=?',
       interval: '=',
       noTransition: '=',
       noPause: '=',


### PR DESCRIPTION
Without this change this error appears and we do not see if the indicator is active :

Error: [$compile:nonassign] Expression 'undefined' in attribute 'active' used with directive 'uibCarousel' is non-assignable!