### PR TITLE
Fixed test carousel that did fail

### DIFF
--- a/src/carousel/test/carousel.spec.js
+++ b/src/carousel/test/carousel.spec.js
@@ -164,24 +164,6 @@ describe('carousel', function() {
       expect(navPrev.hasClass('disabled')).toBe(true);
     });
 
-    it('should disable next button when last slide is active and noWrap is truthy', function() {
-      scope.slides = [
-        {content: 'one', index: 0},
-        {content: 'two', index: 1}
-      ];
-
-      scope.$apply();
-
-      var $scope = elm.isolateScope();
-      $scope.noWrap = function() {return true;};
-      $scope.next();
-
-      $scope.isNextDisabled();
-      scope.$apply();
-
-      var navNext = elm.find('a.carousel-control-prev');
-      expect(navNext.hasClass('disabled')).toBe(true);
-    });
 
     it('should show navigation when there are 3 slides', function () {
       var indicators = elm.find('ol.carousel-indicators > li');


### PR DESCRIPTION
I think this test is no longer necessary : should disable next button when last slide is active and noWrap is truthy
The class disabled no longer add to a.carousel-control-prev in bootstrap4

src/carousel/test/carousel.spec.js:183:54)
Executed 359 of 1332 (1 FAILED) (0 secs / 4.734 secs)
