### PR TITLE
Fix #32 "grunt release" that do not convert HTML templates to js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -546,6 +546,7 @@ module.exports = function(grunt) {
         // Step 2, we queue up additional tasks
         grunt.task.run([
             'conventionalChangelog',
+            'html2js',
             'build',
             'copy',
             'shell:release-prepare',


### PR DESCRIPTION
I realized by launching `grunt -force` because it works and `grunt release` did not work.
