### PR TITLE
Revert "fix(modal): check for overflow hidden"

### DIFF
--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -439,11 +439,9 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.multiMap', 'ui.bootstrap.sta
           }
           $compile(backdropDomEl)(backdropScope);
           $animate.enter(backdropDomEl, appendToElement);
-          if ($uibPosition.isScrollable(appendToElement)) {
-            scrollbarPadding = $uibPosition.scrollbarPadding(appendToElement);
-            if (scrollbarPadding.heightOverflow && scrollbarPadding.scrollbarWidth) {
-              appendToElement.css({paddingRight: scrollbarPadding.right + 'px'});
-            }
+          scrollbarPadding = $uibPosition.scrollbarPadding(appendToElement);
+          if (scrollbarPadding.heightOverflow && scrollbarPadding.scrollbarWidth) {
+            appendToElement.css({paddingRight: scrollbarPadding.right + 'px'});
           }
         }
 


### PR DESCRIPTION
This reverts commit 433e536e6b31ed61d19fc2d2b31a01b05a2b0474.

This "fix" causes the general use case of being attached to the body to fail. This can be seen on the example site, past v2 the padding isn't added when it should be and the page 'jumps' when the scrollbar disappears.

This PR doesn't fix the original issue:
https://github.com/angular-ui/bootstrap/issues/6037

But it does repair the general case which is more important than the edge case that's addressed.
