### PR TITLE
Adjust last animation change to fix test

### DIFF
--- a/src/carousel/carousel.css
+++ b/src/carousel/carousel.css
@@ -1,4 +1,4 @@
 .ng-animate.item:not(.left):not(.right) {
   -webkit-transition: 0s ease-in-out left;
   transition: 0s ease-in-out left
-}t
+}

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -59,6 +59,7 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.multiMap', 'ui.bootstrap.sta
     };
 
     function linkFn(scope, element, attrs) {
+
       // Deferred object that will be resolved when this modal is rendered.
       var modalRenderDeferObj = $q.defer();
       // Resolve render promise post-digest
@@ -67,20 +68,22 @@ angular.module('ui.bootstrap.modal', ['ui.bootstrap.multiMap', 'ui.bootstrap.sta
       });
 
       modalRenderDeferObj.promise.then(function() {
-
         if (attrs.modalInClass) {
           $animate.addClass(element, attrs.modalInClass);
-
-          scope.$on($modalStack.NOW_CLOSING_EVENT, function(e, setIsAsync) {
-            var done = setIsAsync();
-            if (scope.modalOptions.animation) {
-              $animate.removeClass(element, attrs.modalInClass).then(done);
-            } else {
-              done();
-            }
-          });
         }
       });
+
+      if (attrs.modalInClass) {
+        scope.$on($modalStack.NOW_CLOSING_EVENT, function(e, setIsAsync) {
+          var done = setIsAsync();
+          if (scope.modalOptions.animation) {
+            $animate.removeClass(element, attrs.modalInClass).then(done);
+          } else {
+            done();
+          }
+        });
+      }
+
 
     }
   }])


### PR DESCRIPTION
Was getting error:
> Chrome 70.0.3538 (Mac OS X 10.14.0) $uibModal option by option openedClass should not add the modal-open class if modal is closed before animation FAILED

Tried to debug and see why the test was failing.  Looking at the code just led to not knowing how the test ever even could pass since `modal.close` when called immediately after open, always checks the $modalStack before the new modalInstance is even added to it.  Regardless, moved that part of the backdrop close listener outside of the postDigest call.
