### PR TITLE
Fix keyboard navigation in dropdown

### DIFF
--- a/src/dropdown/dropdown.js
+++ b/src/dropdown/dropdown.js
@@ -194,8 +194,8 @@ angular.module('ui.bootstrap.dropdown', ['ui.bootstrap.multiMap', 'ui.bootstrap.
 
   scope.focusDropdownEntry = function(keyCode) {
     var elems = self.dropdownMenu ? //If append to body is used.
-      angular.element(self.dropdownMenu).find('.dropdown-item') :
-      $element.find('div').eq(0).find('a.');
+      angular.element(self.dropdownMenu[0].querySelectorAll('.dropdown-item')) :
+      angular.element($element[0].querySelectorAll('div .dropdown-item'));
 
     switch (keyCode) {
       case 40: {


### PR DESCRIPTION
The previous change assumed jQuery was in use (angular.element uses jQuery Lite by default which does NOT support class names with .find() -  https://docs.angularjs.org/api/ng/function/angular.element).  This change works without wrapping angular.element() around the selectors but I did it to keep it AngularJS-ish (don't really know if there are benefits to making it into a jqLite or jQuery object again).